### PR TITLE
Allow start a container with no entrypoint

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -181,6 +181,20 @@ class Container(object):
             self._remove_container()
             self.container = None
 
+
+    def startWithCommand(self, cmd):
+        """ Starts a detached container for selected image with a custom command"""
+
+        self.container = d.create_container(image=self.image_id,
+                                            detach=True,
+                                            tty=True,
+                                            command=cmd)
+        self.logging.debug("Starting container '%s'..." % self.container.get('Id'))
+        d.start(self.container)
+        self.running = True
+        self.ip_address = self.inspect()['NetworkSettings']['IPAddress']
+
+
     def execute(self, cmd):
         """ executes cmd in container and return its output """
         inst = d.exec_create(container=self.container, cmd=cmd)

--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -5,7 +5,6 @@ import logging
 from steps import TIMEOUT
 from container import Container, ExecException
 
-
 LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 logging.basicConfig(format=LOG_FORMAT)
 
@@ -86,6 +85,20 @@ def start_container_with_args(context, pname="java"):
         kwargs[row['arg']] = row['value']
     container = Container(context.config.userdata['IMAGE'], name=context.scenario.name)
     container.start(**kwargs)
+    context.containers.append(container)
+    wait_for_process(context, pname)
+
+
+@given(u'container is started with command {cmd}')
+@when(u'container is started with command {cmd}')
+def start_container_with_command(context, cmd, pname="java"):
+    """
+    This will start a container with a specific command provided by the user
+    Useful for container that does not have an entrypoint or does not executes nothing
+    i.e. start the container with bash command eh perform some commands on the container
+    """
+    container = Container(context.config.userdata['IMAGE'], name=context.scenario.name)
+    container.startWithCommand(cmd)
     context.containers.append(container)
     wait_for_process(context, pname)
 


### PR DESCRIPTION
This commit allows start a container with a specific command provided by the user
Useful for container that does not have an entrypoint or does not executes nothing
i.e. start the container with bash command eh perform some commands on the container

Example of usage:

```
@jboss-kie/postgresql-extension-openshift-image
  Feature: Verify if PostgreSQL Extension image was correctly built.

    Scenario: Verify if the correct correct files are present in the container
      When container is started with command bash
      Then file /extensions/install.properties should exist
       And file /extensions/install.sh should exist
       And file /extensions/modules/org/postgresqlCustom/main/module.xml should exist
```