### PR TITLE
Add support for running detached processes 

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -195,11 +195,15 @@ class Container(object):
         self.ip_address = self.inspect()['NetworkSettings']['IPAddress']
 
 
-    def execute(self, cmd):
+    def execute(self, cmd, detach=False):
         """ executes cmd in container and return its output """
         inst = d.exec_create(container=self.container, cmd=cmd)
 
-        output = d.exec_start(inst)
+        if (detach):
+            d.exec_start(inst, detach)
+            return None
+
+        output = d.exec_start(inst, detach=detach)
         retcode = d.exec_inspect(inst)['ExitCode']
 
         count = 0

--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -201,7 +201,7 @@ def run_log_contains_msg(context, message, timeout):
 
 
 @then(u'all files under {path} are writeable by current user')
-def ckeck_that_paths_are_writeble(context, path):
+def check_that_paths_are_writeable(context, path):
     container = context.containers[-1]
 
     user = container.execute(cmd="id -u").strip().decode()
@@ -243,6 +243,10 @@ def run_command_unexpect_message(context, cmd, output_phrase, timeout=80):
 def run_command_once(context, cmd):
     run_command_expect_message(context, cmd, None, timeout=0)
 
+@then(u'run {cmd} in container and detach')
+def run_command_and_detach(context, cmd):
+        container = context.containers[-1]
+        container.execute(cmd=cmd, detach=True)
 
 @then(u'run {cmd} in container and check its output for {output_phrase}')
 @then(u'run {cmd} in container and check its output contains {output_phrase}')


### PR DESCRIPTION
this is useful if you want to run a server process after performing some other task, say configuration etc.

Example:

```
  Scenario: Run custom setup in image before launch
    When container is started with command bash
      Then run sed -i 's/some_value/some_replacement_value/' /opt/eap/configuration/standalone/standalone-openshift.xml
      Then run script -c /opt/eap/bin/openshift-launch.sh /tmp/boot.log in container and detach
      Then run ls -l /tmp in container and check its output contains boot.log
      Then file /tmp/boot.log should contain JGroups
      Then file /tmp/boot.log should not contain SHAZAM