### PR TITLE
Convert timeout to float

### DIFF
--- a/steps/xml_steps.py
+++ b/steps/xml_steps.py
@@ -27,6 +27,7 @@ def check_xpath_stripped(context, xml_file, xpath, value):
     return check_xpath_internal(context, xml_file, xpath, value, True)
 
 def check_xpath_internal(context, xml_file, xpath, value, strip, timeout=TIMEOUT):
+    timeout = float(timeout)
     start_time = time.time()
     container = context.containers[-1]
 


### PR DESCRIPTION
@goldmann without this I get errors like

```
    And XML file /opt/eap/standalone/configuration/standalone-openshift.xml should have 1 elements on XPath //*[local-name()='datasource'] and wait 30 seconds                                # steps/xml_steps.py:63 0.000s
      Traceback (most recent call last):
        File "/usr/lib/python3.7/site-packages/behave/model.py", line 1329, in run
          match.run(runner.context)
        File "/usr/lib/python3.7/site-packages/behave/matchers.py", line 98, in run
          self.func(context, *args, **kwargs)
        File "steps/xml_steps.py", line 66, in check_xml_element_count
          check_xpath_internal(context, xml_file, 'count(' + xpath + ')', count, False, timeout)
        File "steps/xml_steps.py", line 33, in check_xpath_internal
          while time.time() < start_time + timeout:
      TypeError: unsupported operand type(s) for +: 'float' and 'str'
```