### PR TITLE
S2i, build without run. Start named container with command

### DIFF
--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -91,7 +91,8 @@ def start_container_with_args(context, pname="java"):
 
 @given(u'container is started with command {cmd}')
 @when(u'container is started with command {cmd}')
-def start_container_with_command(context, cmd, pname="java"):
+@when(u'container {name} is started with command {cmd}')
+def start_container_with_command(context, cmd, name="", pname="java"):
     """
     This will start a container with a specific command provided by the user
     Useful for container that does not have an entrypoint or does not executes nothing
@@ -102,7 +103,7 @@ def start_container_with_command(context, cmd, pname="java"):
         for row in context.table:
             env[row['variable']] = row['value']
 
-    container = Container(context.config.userdata['IMAGE'], name=context.scenario.name)
+    container = Container(name + context.config.userdata['IMAGE'], name=context.scenario.name)
     kwargs = {"command": cmd, "environment": env}
     container.startWithCommand(**kwargs)
 

--- a/steps/s2i_steps.py
+++ b/steps/s2i_steps.py
@@ -52,14 +52,16 @@ def s2i_inner(context, application, path='.', env="", incremental=False, tag="ma
 @given(u's2i build {application} from {path} with env using {tag}')
 @given(u's2i build {application} from {path} with env and {incremental}')
 @given(u's2i build {application} from {path} with env and {incremental} using {tag}')
-def s2i_build(context, application, path='.', env="", incremental=False, tag="master"):
+@given(u's2i build {application} from {path} with env and {incremental} using {tag} and run {run}')
+def s2i_build(context, application, path='.', env="", incremental=False, tag="master", run=True):
     """Perform an S2I build, that must succeed."""
     if s2i_inner(context, application, path, env, incremental, tag):
         image_id = "integ-" + context.image
         logging.info("S2I build succeeded, image %s was built" % image_id)
-        container = Container(image_id, name=context.scenario.name)
-        container.start()
-        context.containers.append(container)
+        if run:
+            container = Container(image_id, name=context.scenario.name)
+            container.start()
+            context.containers.append(container)
     else:
         raise Exception("S2I build failed, check logs!")
 

--- a/steps/s2i_steps.py
+++ b/steps/s2i_steps.py
@@ -52,7 +52,6 @@ def s2i_inner(context, application, path='.', env="", incremental=False, tag="ma
 @given(u's2i build {application} from {path} with env using {tag}')
 @given(u's2i build {application} from {path} with env and {incremental}')
 @given(u's2i build {application} from {path} with env and {incremental} using {tag}')
-@given(u's2i build {application} from {path} with env and {incremental} using {tag} and run {run}')
 def s2i_build(context, application, path='.', env="", incremental=False, tag="master", run=True):
     """Perform an S2I build, that must succeed."""
     if s2i_inner(context, application, path, env, incremental, tag):
@@ -65,6 +64,9 @@ def s2i_build(context, application, path='.', env="", incremental=False, tag="ma
     else:
         raise Exception("S2I build failed, check logs!")
 
+@given(u's2i build {application} from {path} with env and {incremental} using {tag} without running')
+def s2i_build_no_run(context, application, path='.', env="", incremental=False, tag="master"):
+    s2i_build(context, application, path, env, incremental, tag, False)
 
 @given(u'failing s2i build {application} from {path} using {tag}')
 def failing_s2i_build(context, application, path='.', env="", incremental=False, tag="master"):


### PR DESCRIPTION
This is to address cases where we want to start the s2i built image with a command (eg: bash).
- s2i build only (run False)
- Execute a named container with a cmd.

For example:
Given s2i build <app> from . with env and False using master and run False
When container integ- is started with command bash
...

