### PR TITLE
Provide a step that start a container with a specific entry-point

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -48,7 +48,7 @@ class Container(object):
     Object representing a docker test container, it is used in tests
     """
 
-    def __init__(self, image_id, name=None, remove_image=False, output_dir="output", save_output=True, volumes=None, **kwargs):
+    def __init__(self, image_id, name=None, remove_image=False, output_dir="output", save_output=True, volumes=None, entrypoint=None, **kwargs):
         self.image_id = image_id
         self.container = None
         self.name = name
@@ -61,7 +61,7 @@ class Container(object):
         self.running = False
         self.volumes = volumes
         self.environ = {}
-        self.entrypoint = None
+        self.entrypoint = entrypoint
 
         # get volumes from env (CTF_DOCKER_VOLUME=out:in:z,out2:in2:z)
         try:
@@ -146,16 +146,6 @@ class Container(object):
         d.start(self.container)
         self.running = True
         self.ip_address = self.inspect()['NetworkSettings']['IPAddress']
-
-    def startWithEntryPoint(self, entrypoint):
-        """ Starts a detached container for selected image with a custom entrypoint"""
-        self.entrypoint = entrypoint
-        self._create_container(tty=True)
-        self.logging.debug("Starting container '%s'..." % self.container.get('Id'))
-        d.start(self.container)
-        self.running = True
-        self.ip_address = self.inspect()['NetworkSettings']['IPAddress']    
-
 
     def execute(self, cmd, detach=False):
         """ executes cmd in container and return its output """

--- a/steps/container.py
+++ b/steps/container.py
@@ -61,6 +61,7 @@ class Container(object):
         self.running = False
         self.volumes = volumes
         self.environ = {}
+        self.entrypoint = None
 
         # get volumes from env (CTF_DOCKER_VOLUME=out:in:z,out2:in2:z)
         try:
@@ -145,6 +146,15 @@ class Container(object):
         d.start(self.container)
         self.running = True
         self.ip_address = self.inspect()['NetworkSettings']['IPAddress']
+
+    def startWithEntryPoint(self, entrypoint):
+        """ Starts a detached container for selected image with a custom entrypoint"""
+        self.entrypoint = entrypoint
+        self._create_container(tty=True)
+        self.logging.debug("Starting container '%s'..." % self.container.get('Id'))
+        d.start(self.container)
+        self.running = True
+        self.ip_address = self.inspect()['NetworkSettings']['IPAddress']    
 
 
     def execute(self, cmd, detach=False):
@@ -248,6 +258,7 @@ class Container(object):
 
         self.container = d.create_container(image=self.image_id,
                                             detach=True,
+                                            entrypoint=self.entrypoint,
                                             volumes=volume_mount_points,
                                             host_config=d.create_host_config(**host_args),
                                             **kwargs)

--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -94,8 +94,8 @@ def start_container_with_args(context, pname="java"):
 
 @given(u'container is started with entrypoint {entrypoint}')
 def start_container_with_entrypoint(context, entrypoint):
-    container = Container(context.config.userdata['IMAGE'], name=context.scenario.name)
-    container.startWithEntryPoint(entrypoint)
+    container = Container(context.config.userdata['IMAGE'], name=context.scenario.name, entrypoint=entrypoint)
+    container.start()
     context.containers.append(container)
     wait_for_process(context, entrypoint)    
 

--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -92,6 +92,13 @@ def start_container_with_args(context, pname="java"):
     context.containers.append(container)
     wait_for_process(context, pname)
 
+@given(u'container is started with entrypoint {entrypoint}')
+def start_container_with_entrypoint(context, entrypoint):
+    container = Container(context.config.userdata['IMAGE'], name=context.scenario.name)
+    container.startWithEntryPoint(entrypoint)
+    context.containers.append(container)
+    wait_for_process(context, entrypoint)    
+
 
 @given(u'container is started with command {cmd}')
 @when(u'container is started with command {cmd}')


### PR DESCRIPTION
This step allows the testing of containers having a defined entry point and not accepting commands.

Example (using sh as entrypoint)

```
 Scenario: Check that encoding environment variables are defined
        Given container is started with entrypoint sh
        Then run sh -c 'env' in container and immediately check its output contains LANG=en_US.UTF-8
             and run sh -c 'env' in container and immediately check its output contains LANGUAGE=en_US:en
             and run sh -c 'env' in container and immediately check its output contains LC_ALL=en_US.UTF-8
```

Fixes https://github.com/cekit/cekit/issues/659