### PR TITLE
Adjust Python for comparisons with literals

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -167,7 +167,7 @@ class Container(object):
             if count > 15:
                 raise ExecException("Command %s timed out, output: %s" % (cmd, output))
 
-        if retcode is not 0:
+        if retcode != 0:
             raise ExecException("Command %s failed to execute, return code: %s" % (cmd, retcode), output)
 
         return output

--- a/steps/container_steps.py
+++ b/steps/container_steps.py
@@ -255,7 +255,7 @@ def check_that_paths_are_writeable(context, path):
 
     output = container.execute(cmd="find %s ! ( ( -user %s -perm -u=w ) -o ( -group %s -perm -g=w ) ) -ls" % (path, user, group))
 
-    if len(output) is 0:
+    if len(output) == 0:
         return True
 
     raise Exception("Not all files on %s path are writeable by %s user or %s group" % (path, user, group), output)

--- a/steps/steps.py
+++ b/steps/steps.py
@@ -63,7 +63,7 @@ def _execute(command, log_output=True):
 
         retcode = proc.wait()
 
-        if retcode is not 0:
+        if retcode != 0:
             logging.error(
                 "Command '%s' returned code was %s, check logs" % (command, retcode))
             return False


### PR DESCRIPTION
This removes some warnings that modern Python's emit when using
'is' and 'is not' in a comparison with a literal.

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>