### PR TITLE
Overhaul instantiating docker API class

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -31,7 +31,10 @@ import tarfile
 import tempfile
 import time
 
-d = docker.APIClient()
+# A future version of Cekit will expose this to us, for now we hard-code
+DOCKER_API_VERSION = "1.35"
+
+d = docker.APIClient(version=DOCKER_API_VERSION)
 
 
 class ExecException(Exception):

--- a/steps/container.py
+++ b/steps/container.py
@@ -31,10 +31,7 @@ import tarfile
 import tempfile
 import time
 
-try:
-    d = docker.Client(version="1.22")
-except:
-    d = docker.APIClient(version="1.22")
+d = docker.APIClient()
 
 
 class ExecException(Exception):

--- a/steps/image_steps.py
+++ b/steps/image_steps.py
@@ -3,12 +3,7 @@ import docker
 
 from behave import then
 
-
-try:
-    DOCKER_CLIENT = docker.Client(version="1.22")
-except:
-    DOCKER_CLIENT = docker.APIClient(version="1.22")
-
+DOCKER_CLIENT = docker.APIClient()
 
 @then(u'the image should contain label {label}')
 @then(u'the image should contain label {label} {check} value {value}')

--- a/steps/image_steps.py
+++ b/steps/image_steps.py
@@ -3,7 +3,10 @@ import docker
 
 from behave import then
 
-DOCKER_CLIENT = docker.APIClient()
+# A future version of Cekit will expose this to us, for now we hard-code
+DOCKER_API_VERSION = "1.35"
+
+DOCKER_CLIENT = docker.APIClient(version=DOCKER_API_VERSION)
 
 @then(u'the image should contain label {label}')
 @then(u'the image should contain label {label} {check} value {value}')


### PR DESCRIPTION
Don't pin docker APIClient to version 1.22.

Don't try to instantiate docker.Client before trying docker.APIClient: the former dates from the days the library was called "docker-py", the last release for which was November 2016. EPEL 7 and onwards provide the newer Python docker library, so I doubt there's anyone left using the older one.

This now aligns with Cekit.

(I'm still running local tests against this now)