### PR TITLE
container.execute: fix when exec_start completes fast

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -147,7 +147,7 @@ class Container(object):
         self.running = True
         self.ip_address = self.inspect()['NetworkSettings']['IPAddress']
 
-    def execute(self, cmd, detach=False):
+    def execute(self, cmd, detach=False, timeout=60):
         """ executes cmd in container and return its output """
         self.logger.debug("container.execute(%s,%s)" % (cmd,detach))
         inst = d.exec_create(container=self.container, cmd=cmd)
@@ -161,9 +161,9 @@ class Container(object):
         p = ctx.Process(target=lambda q: q.put(d.exec_start(inst, detach=detach)), args=(q,))
         p.start()
 
-        if None == p.join(60): # timeout in secs
+        if None == p.join(timeout) and p.exitcode == None:
             p.terminate()
-            raise ExecException("container.execute: timeout reading from exec (command '{}')".format(cmd))
+            raise ExecException("container.execute: timeout reading from exec_start (command '{}')".format(cmd))
 
         output = q.get()
         retcode = d.exec_inspect(inst)['ExitCode']


### PR DESCRIPTION
p.join will return None in two situations: when the timeout is reached, and if the process has completed already.

Adjust the check so that we throw an exception in the former case but not the latter.

----

This hopefully fixes a reported error in running the test suite for https://github.com/wildfly/wildfly-s2i/actions/runs/8345796441/job/22876447353#step:16:2666

----

For this wishing to test this: at the moment <https://github.com/jmtd/behave-test-steps> branch `v1` has this patch.