### PR TITLE
Some adjustments to use behave tests with Podman

### DIFF
--- a/steps/container.py
+++ b/steps/container.py
@@ -35,7 +35,7 @@ import multiprocessing as mp
 # A future version of Cekit will expose this to us, for now we hard-code
 DOCKER_API_VERSION = "1.35"
 
-base_url = os.environ.get("DOCKER_HOST", 'unix:///var/run/docker.sock')
+base_url = os.environ.get("DOCKER_HOST", docker.constants.DEFAULT_UNIX_SOCKET)
 d = docker.APIClient(version=DOCKER_API_VERSION, base_url=base_url)
 
 

--- a/steps/container.py
+++ b/steps/container.py
@@ -35,7 +35,8 @@ import multiprocessing as mp
 # A future version of Cekit will expose this to us, for now we hard-code
 DOCKER_API_VERSION = "1.35"
 
-d = docker.APIClient(version=DOCKER_API_VERSION)
+base_url = os.environ.get("DOCKER_HOST", 'unix:///var/run/docker.sock')
+d = docker.APIClient(version=DOCKER_API_VERSION, base_url=base_url)
 
 
 class ExecException(Exception):

--- a/steps/image_steps.py
+++ b/steps/image_steps.py
@@ -1,3 +1,4 @@
+import os
 import docker
 
 
@@ -6,7 +7,8 @@ from behave import then
 # A future version of Cekit will expose this to us, for now we hard-code
 DOCKER_API_VERSION = "1.35"
 
-DOCKER_CLIENT = docker.APIClient(version=DOCKER_API_VERSION)
+base_url = os.environ.get("DOCKER_HOST", 'unix:///var/run/docker.sock')
+DOCKER_CLIENT = docker.APIClient(version=DOCKER_API_VERSION, base_url=base_url)
 
 @then(u'the image should contain label {label}')
 @then(u'the image should contain label {label} {check} value {value}')

--- a/steps/image_steps.py
+++ b/steps/image_steps.py
@@ -7,7 +7,7 @@ from behave import then
 # A future version of Cekit will expose this to us, for now we hard-code
 DOCKER_API_VERSION = "1.35"
 
-base_url = os.environ.get("DOCKER_HOST", 'unix:///var/run/docker.sock')
+base_url = os.environ.get("DOCKER_HOST", docker.constants.DEFAULT_UNIX_SOCKET)
 DOCKER_CLIENT = docker.APIClient(version=DOCKER_API_VERSION, base_url=base_url)
 
 @then(u'the image should contain label {label}')

--- a/steps/s2i_steps.py
+++ b/steps/s2i_steps.py
@@ -29,10 +29,19 @@ def s2i_inner(context, application, path='.', env="", incremental=False, tag="ma
         mirror = "-e 'MAVEN_MIRROR_URL=%s'" % os.getenv("MAVEN_MIRROR_URL")
 
     image_id = "integ-" + context.image
-    command = "s2i build --loglevel=5 --pull-policy if-not-present %s --context-dir=%s -r=%s %s %s %s %s %s %s" % (
-        mirror, path, tag, env, application, context.image, image_id, "--incremental" if incremental else "",
-        "--runtime-image="+runtime_image if runtime_image else ""
-    )
+
+    command = f"""s2i build --loglevel=5 --pull-policy if-not-present\
+            {mirror}\
+            --context-dir={path}\
+            -r={tag}\
+            {env}\
+            {application}\
+            {context.image}\
+            {image_id}\
+            {"--incremental" if incremental else ""}\
+            {"--runtime-image="+runtime_image if runtime_image else ""}\
+    """
+
     logger.info("Executing new S2I build with the command [%s]..." % command)
 
     success, output = _execute(command)


### PR DESCRIPTION
This introduces an environment variable CTF_API_SOCK, defaulting to `unix://var/run/docker.sock`, to permit a user to point it at another API end-point, such as Podman.