### PR TITLE
bump GHA timeout to 120s

### DIFF
--- a/.github/workflows/ubi9-openjdk-17-runtime.yml
+++ b/.github/workflows/ubi9-openjdk-17-runtime.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   openjdkci:
     name: behave-test-steps regression tests
-    timeout-minutes: 60
+    timeout-minutes: 120
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
This should probably not be merged, I'm just testing the theory that 60 minutes is suffucient