### PR TITLE
_execute: return tuple of success, logs

### DIFF
--- a/steps/s2i_steps.py
+++ b/steps/s2i_steps.py
@@ -35,10 +35,9 @@ def s2i_inner(context, application, path='.', env="", incremental=False, tag="ma
     )
     logger.info("Executing new S2I build with the command [%s]..." % command)
 
-    output = _execute(command)
-    if output:
-        context.config.userdata['s2i_build_log'] = output
-    return output
+    success, output = _execute(command)
+    context.config.userdata['s2i_build_log'] = output
+    return success
 
 
 @given(u's2i build {application} from {path} without running')

--- a/steps/steps.py
+++ b/steps/steps.py
@@ -6,6 +6,7 @@ import logging
 import select
 import socket
 import fcntl
+from typing import Tuple
 
 from behave import then, given
 from container import ExecException
@@ -15,7 +16,7 @@ logger = logging.getLogger("cekit")
 TIMEOUT = int(os.getenv('BEHAVE_TIMEOUT', '30'))
 
 
-def _execute(command, log_output=True):
+def _execute(command, log_output=True) -> Tuple[bool, str]:
     """
     Helper method to execute a shell command and redirect the logs to logger
     with proper log level.

--- a/steps/steps.py
+++ b/steps/steps.py
@@ -44,8 +44,8 @@ def _execute(command, log_output=True):
             fcntl.fcntl(proc.stdout.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK,
         )
 
+        out = ""
         if log_output:
-            out = ""
 
             while proc.poll() is None:
                 readx = select.select([proc.stdout, proc.stderr], [], [])[0]
@@ -63,16 +63,13 @@ def _execute(command, log_output=True):
         if retcode != 0:
             logger.error(
                 "Command '%s' returned code was %s, check logs" % (command, retcode))
-            return False
+            return False, out
 
     except subprocess.CalledProcessError:
         logger.error("Command '%s' failed, check logs" % command)
-        return False
+        return False, out
 
-    if log_output:
-        return out
-    else:
-        return True
+    return True, out
 
 
 @then(u'check that page is not served')


### PR DESCRIPTION
Adjust _execute to return the success/failure status of the command and the commands output as two separate values, paired.

Adjust s2i_inner to reflect the altered return type, and to assign the returned output to s2i_build_log in the success and failure cases.

Fixes #72.